### PR TITLE
Change presentationModeExit keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         ],
         "keybindings": [{
             "command": "extension.presentationModeExit",
-            "key": "escape",
+            "key": "escape escape",
             "when": "inPresentationMode"
         }],
         "configuration": {


### PR DESCRIPTION
Fixes #3 by matching `exitZenMode` mode. Zen mode can still be exited using `toggleZenMode`.